### PR TITLE
Allow a custom httpsAgent to be passed in as part of config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ function format(logData) {
  *      "logType": "application",        // type of the application
  *      "logChannel": "test",        // channel of the application
  *      "url": "http://lfs-server/_bulk",  // logstash receiver servlet URL
+ *      "httpsAgent": https.Agent, // optional, offers finer control over how the logstash API is called
  *   }
  */
 function logstashHTTPAppender(config) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,12 +36,18 @@ function format(logData) {
  *   }
  */
 function logstashHTTPAppender(config) {
-  const sender = axios.create({
+  const _config = {
     baseURL: config.url,
     timeout: config.timeout || 5000,
     headers: { 'Content-Type': 'application/x-ndjson' },
-    withCredentials: true,
-  });
+    withCredentials: true
+  };
+  
+  if(config.httpsAgent){
+    _config.httpsAgent = config.httpsAgent;
+  }
+  
+  const sender = axios.create(_config);
 
   return function log(event) {
     const logstashEvent = [


### PR DESCRIPTION
Rationale: A common issue with sending API requests over https is determining what to do if the server is using a self-signed certificate. While we could set an environment variable for ignoring unauthorized SSL certs, we often don't want to do that, and instead configure policy based on the server we are hitting. For example, if we know that one server is a development instance and another is production, we want to use an https agent that ignores ssl issues for development but not production.

